### PR TITLE
Split MediaWikiServicesHook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -16,13 +16,16 @@
   },
   "HookHandlers": {
     "default": {
-      "class": "MediaWiki\\Extension\\PageViewInfoGA\\Hooks",
+      "class": "MediaWiki\\Extension\\PageViewInfoGA\\Hooks\\Main",
       "services": ["MainConfig"]
+    },
+    "MediaWikiServices": {
+      "class": "MediaWiki\\Extension\\PageViewInfoGA\\Hooks\\MediaWikiServices"
     }
   },
   "Hooks": {
     "BeforePageDisplay": "default",
-    "MediaWikiServices": "default"
+    "MediaWikiServices": "MediaWikiServices"
   },
   "MessagesDirs": {
     "PageViewInfoGA": ["i18n"]

--- a/src/Hooks/Main.php
+++ b/src/Hooks/Main.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\PageViewInfoGA\Hooks;
 
 use Config;
 use Html;
+use MediaWiki\Extension\PageViewInfoGA\Constants;
 
 class Main implements
 	\MediaWiki\Hook\BeforePageDisplayHook

--- a/src/Hooks/Main.php
+++ b/src/Hooks/Main.php
@@ -6,8 +6,7 @@ use Config;
 use Html;
 
 class Main implements
-	\MediaWiki\Hook\BeforePageDisplayHook,
-	\MediaWiki\Hook\MediaWikiServicesHook
+	\MediaWiki\Hook\BeforePageDisplayHook
 	{
 	/**
 	 * @var Config

--- a/src/Hooks/Main.php
+++ b/src/Hooks/Main.php
@@ -1,14 +1,11 @@
 <?php
 
-namespace MediaWiki\Extension\PageViewInfoGA;
+namespace MediaWiki\Extension\PageViewInfoGA\Hooks;
 
 use Config;
 use Html;
-use MediaWiki\Extensions\PageViewInfo\CachedPageViewService;
-use MediaWiki\Logger\LoggerFactory;
-use ObjectCache;
 
-class Hooks implements
+class Main implements
 	\MediaWiki\Hook\BeforePageDisplayHook,
 	\MediaWiki\Hook\MediaWikiServicesHook
 	{
@@ -80,47 +77,5 @@ class Hooks implements
 		$jsMap = implode( ',', $jsMap );
 		$jsMap = '{' . $jsMap . '}';
 		return $jsMap;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function onMediaWikiServices( $services ) {
-		$config = $this->config;
-		$profileId = $config->get( Constants::CONFIG_KEY_PROFILE_ID );
-		if ( !$profileId ) {
-			return;
-		}
-		$credentialsFile = $config->get( Constants::CONFIG_KEY_CREDENTIALS_FILE );
-		$customMap = $config->get( Constants::CONFIG_KEY_CUSTOM_MAP );
-		$readCustomDimensions = $config->get( Constants::CONFIG_KEY_READ_CUSTOM_DIMENSIONS );
-		$cache = ObjectCache::getLocalClusterInstance();
-		$logger = LoggerFactory::getInstance( 'PageViewInfoGA' );
-		$cachedDays = max( 30, $config->get( 'PageViewApiMaxDays' ) );
-
-		$services->redefineService(
-			'PageViewService',
-			static function () use (
-				$credentialsFile,
-				$profileId,
-				$customMap,
-				$readCustomDimensions,
-				$cache,
-				$logger,
-				$cachedDays
-				) {
-				$service = new GoogleAnalyticsPageViewService( [
-					'credentialsFile' => $credentialsFile,
-					'profileId' => $profileId,
-					'customMap' => $customMap,
-					'readCustomDimensions' => $readCustomDimensions,
-				] );
-
-				$cachedService = new CachedPageViewService( $service, $cache );
-				$cachedService->setCachedDays( $cachedDays );
-				$cachedService->setLogger( $logger );
-				return $cachedService;
-			}
-		);
 	}
 }

--- a/src/Hooks/MediaWikiServices.php
+++ b/src/Hooks/MediaWikiServices.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MediaWiki\Extension\PageViewInfoGA\Hooks;
+
+use MediaWiki\Extension\PageViewInfoGA\Constants;
+use MediaWiki\Extension\PageViewInfoGA\GoogleAnalyticsPageViewService;
+use MediaWiki\Extensions\PageViewInfo\CachedPageViewService;
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices as MediaWikiMediaWikiServices;
+use ObjectCache;
+
+class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function onMediaWikiServices( $services ) {
+		$config = MediaWikiMediaWikiServices::getInstance()->getMainConfig();
+		$profileId = $config->get( Constants::CONFIG_KEY_PROFILE_ID );
+		if ( !$profileId ) {
+			return;
+		}
+		$credentialsFile = $config->get( Constants::CONFIG_KEY_CREDENTIALS_FILE );
+		$customMap = $config->get( Constants::CONFIG_KEY_CUSTOM_MAP );
+		$readCustomDimensions = $config->get( Constants::CONFIG_KEY_READ_CUSTOM_DIMENSIONS );
+		$cache = ObjectCache::getLocalClusterInstance();
+		$logger = LoggerFactory::getInstance( 'PageViewInfoGA' );
+		$cachedDays = max( 30, $config->get( 'PageViewApiMaxDays' ) );
+
+		$services->redefineService(
+			'PageViewService',
+			static function () use (
+				$credentialsFile,
+				$profileId,
+				$customMap,
+				$readCustomDimensions,
+				$cache,
+				$logger,
+				$cachedDays
+				) {
+				$service = new GoogleAnalyticsPageViewService( [
+					'credentialsFile' => $credentialsFile,
+					'profileId' => $profileId,
+					'customMap' => $customMap,
+					'readCustomDimensions' => $readCustomDimensions,
+				] );
+
+				$cachedService = new CachedPageViewService( $service, $cache );
+				$cachedService->setCachedDays( $cachedDays );
+				$cachedService->setLogger( $logger );
+				return $cachedService;
+			}
+		);
+	}
+}


### PR DESCRIPTION
Resolves UnexpectedValueException.
```
UnexpectedValueException: The handler for the hook MediaWikiServices registered in /workspace/src/extensions/PageViewInfoGA/extension.json has a service dependency, but this hook does not allow it.
Backtrace:
from /workspace/src/includes/HookContainer/HookContainer.php(466)
#0 /workspace/src/includes/HookContainer/HookContainer.php(156): MediaWiki\HookContainer\HookContainer->getHandlers(string, array)
#1 /workspace/src/includes/HookContainer/HookRunner.php(2527): MediaWiki\HookContainer\HookContainer->run(string, array, array)
#2 /workspace/src/includes/MediaWikiServices.php(262): MediaWiki\HookContainer\HookRunner->onMediaWikiServices(MediaWiki\MediaWikiServices)
#3 /workspace/src/includes/Hooks.php(173): MediaWiki\MediaWikiServices::getInstance()
#4 /workspace/src/includes/Setup.php(712): Hooks::runner()
#5 /workspace/src/maintenance/doMaintenance.php(90): require_once(string)
#6 /workspace/src/maintenance/update.php(264): require_once(string)
#7 {main}
```

https://github.com/femiwiki/femiwiki/issues/283