### PR TITLE
Use globals in MediaWikiServicesHook

### DIFF
--- a/src/Hooks/MediaWikiServices.php
+++ b/src/Hooks/MediaWikiServices.php
@@ -2,11 +2,9 @@
 
 namespace MediaWiki\Extension\PageViewInfoGA\Hooks;
 
-use MediaWiki\Extension\PageViewInfoGA\Constants;
 use MediaWiki\Extension\PageViewInfoGA\GoogleAnalyticsPageViewService;
 use MediaWiki\Extensions\PageViewInfo\CachedPageViewService;
 use MediaWiki\Logger\LoggerFactory;
-use MediaWiki\MediaWikiServices as MediaWikiMediaWikiServices;
 use ObjectCache;
 
 class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
@@ -15,17 +13,22 @@ class MediaWikiServices implements \MediaWiki\Hook\MediaWikiServicesHook {
 	 * @inheritDoc
 	 */
 	public function onMediaWikiServices( $services ) {
-		$config = MediaWikiMediaWikiServices::getInstance()->getMainConfig();
-		$profileId = $config->get( Constants::CONFIG_KEY_PROFILE_ID );
+		global $wgPageViewInfoGAProfileId,
+			$wgPageViewInfoGACredentialsFile,
+			$wgPageViewInfoGAWriteCustomMap,
+			$wgPageViewInfoGAReadCustomDimensions,
+			$wgPageViewApiMaxDays;
+
+		$profileId = $wgPageViewInfoGAProfileId;
 		if ( !$profileId ) {
 			return;
 		}
-		$credentialsFile = $config->get( Constants::CONFIG_KEY_CREDENTIALS_FILE );
-		$customMap = $config->get( Constants::CONFIG_KEY_CUSTOM_MAP );
-		$readCustomDimensions = $config->get( Constants::CONFIG_KEY_READ_CUSTOM_DIMENSIONS );
+		$credentialsFile = $wgPageViewInfoGACredentialsFile;
+		$customMap = $wgPageViewInfoGAWriteCustomMap;
+		$readCustomDimensions = $wgPageViewInfoGAReadCustomDimensions;
 		$cache = ObjectCache::getLocalClusterInstance();
 		$logger = LoggerFactory::getInstance( 'PageViewInfoGA' );
-		$cachedDays = max( 30, $config->get( 'PageViewApiMaxDays' ) );
+		$cachedDays = max( 30, $wgPageViewApiMaxDays );
 
 		$services->redefineService(
 			'PageViewService',


### PR DESCRIPTION
To avoid "Deprecated: Premature access to service 'MainConfig'"